### PR TITLE
Add linebreak in console.log in downloadVodURI for clarity

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,8 @@ async function downloadVodURI(writer, playlist, p) {
     console.log(`
 Location: ${path.resolve(process.cwd(), writer.path)}
 Quality: ${playlist.attributes.RESOLUTION.height}p (${playlist.attributes.VIDEO})
-Duration: ${humanizeDuration(dayjs.duration(seconds * 1000))}`);
+Duration: ${humanizeDuration(dayjs.duration(seconds * 1000))}
+`);
 
   const startIndex = playlistM3U.discontinuityStarts.length
     ? playlistM3U.discontinuityStarts[0]


### PR DESCRIPTION
Added a linebreak for a console.log which was causing this: 

![image](https://user-images.githubusercontent.com/7773454/105112074-836c4c00-5ac2-11eb-8cbb-fb7437d6b0e5.png)
