### PR TITLE
Fix issue in fetchVodCredentials when vodID is a number

### DIFF
--- a/index.js
+++ b/index.js
@@ -113,7 +113,7 @@ async function fetchVodCredentials(vodID) {
         isLive: false,
         login: "",
         isVod: true,
-        vodID,
+        vodID: String(vodID),
         playerType: "site",
       },
     }),


### PR DESCRIPTION
If vodID is a primitive number type, this will trigger a "TypeError: Cannot read property 'value' of undefined" at line 129 because the query will result in an error "wrong type for ID: float64". Obligatorily turning the vodID into a string fixes the issue.